### PR TITLE
Missing DI on MainPage init

### DIFF
--- a/EdSampleBlazor/App.xaml.cs
+++ b/EdSampleBlazor/App.xaml.cs
@@ -7,11 +7,11 @@ namespace EdSampleBlazor
 {
 	public partial class App : Application
 	{
-		public App()
+		public App(CounterState counterState)
 		{
 			InitializeComponent();
 
-			MainPage = new MainPage();
+			MainPage = new MainPage(counterState);
 		}
 	}
 }


### PR DESCRIPTION
There was a compiler error on Line 14. MainPage requires a constructor to init. DI needed to be resolved on App because MainPage is constructed manually here.